### PR TITLE
add term-multiselect arg filter, and placeholder support

### DIFF
--- a/templates/form-fields/term-multiselect-field.php
+++ b/templates/form-fields/term-multiselect-field.php
@@ -12,13 +12,17 @@ if ( isset( $field['value'] ) ) {
 
 wp_enqueue_script( 'wp-job-manager-term-multiselect' );
 
-job_manager_dropdown_categories( array( 
+$args = array(
 	'taxonomy'     => $field['taxonomy'],
-	'hierarchical' => 1, 
-	'name'         => isset( $field['name'] ) ? $field['name'] : $key, 
-	'orderby'      => 'name', 
+	'hierarchical' => 1,
+	'name'         => isset( $field['name'] ) ? $field['name'] : $key,
+	'orderby'      => 'name',
 	'selected'     => $selected,
-	'hide_empty'   => false,
-) );
+	'hide_empty'   => FALSE
+);
+
+if( isset( $field['placeholder'] ) && ! empty( $field['placeholder'] ) ) $args['placeholder'] = $field['placeholder'];
+
+job_manager_dropdown_categories( apply_filters( 'job_manager_term_multiselect_field_args', $args ) );
 
 if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo $field['description']; ?></small><?php endif; ?>


### PR DESCRIPTION
Currently term-multiselect only shows placeholder as "Choose a category" and does not support setting placeholder, even if using term-mutliselect for something other than job category.

The reason I added the code the way I did was to still support the default placeholder "Choose a category", if you pass placeholder as empty, select2 will automatically set placeholder to "Choose an Option".

With the code structured this way the user can just use a space for the placeholder if they want it blank, leave the field blank for using default, or set it to whatever they would like.

Also added a filter for the arguments for any possible future changes