### PR TITLE
Allow override of admin fields by checking for action before core method

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -303,10 +303,11 @@ class WP_Job_Manager_Writepanels {
 		foreach ( $this->job_listing_fields() as $key => $field ) {
 			$type = ! empty( $field['type'] ) ? $field['type'] : 'text';
 
-			if ( method_exists( $this, 'input_' . $type ) )
-				call_user_func( array( $this, 'input_' . $type ), $key, $field );
-			else
+			if ( has_action( 'job_manager_input_' . $type ) ) {
 				do_action( 'job_manager_input_' . $type, $key, $field );
+			} elseif ( method_exists( $this, 'input_' . $type ) ) {
+				call_user_func( array( $this, 'input_' . $type ), $key, $field );
+			}
 		}
 
 		do_action( 'job_manager_job_listing_data_end', $thepostid );


### PR DESCRIPTION
Currently there is no way to override the core input methods as they do not use templates and the easiest solution I could think of was to check for an action before the method. 

This allows other plugins/themes to customize the field output even if there is a core method for that input type.

Maybe admin fields should use templates as well?  This would be the quickest fix, but may be good to look at possibly using templates for admin fields in the future .... just a thought