### PR TITLE
Clean post cache after updating menu_order

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -34,7 +34,6 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'add_post_meta', array( $this, 'maybe_add_geolocation_data' ), 10, 3 );
 		add_action( 'update_post_meta', array( $this, 'maybe_update_geolocation_data' ), 10, 4 );
 		add_action( 'update_post_meta', array( $this, 'maybe_update_menu_order' ), 10, 4 );
-		add_action( 'added_post_meta', array( $this, 'maybe_update_menu_order' ), 10, 4 );
 		add_action( 'wp_insert_post', array( $this, 'maybe_add_default_meta_data' ), 10, 2 );
 
 		// WP ALL Import
@@ -523,6 +522,7 @@ class WP_Job_Manager_Post_Types {
 		} else {
 			$wpdb->update( $wpdb->posts, array( 'menu_order' => 0 ), array( 'ID' => $object_id, 'menu_order' => -1 ) );
 		}
+		clean_post_cache( '$object_id' );
 	}
 
 	/**


### PR DESCRIPTION
After running `$wpdb->update` to change the menu_order for featured
listings, we need to clean the post cache, similar to how this is
handled in `wp_update_post` and `wp_insert_post`. If the post cache isn't
cleaned, the menu_order of -1 is not saved to the database when object caching is active.

Removed `added_post_meta` action hook for `maybe_update_menu_order`. This is
not necessary as the first step in creating a job listing is to set
`_featured` to 0. All subsequent post meta changes for `_featured` are
therefore updates.